### PR TITLE
chore(renovate): give access to `@sanity/sanitype`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>sanity-io/renovate-config"]
+  "extends": ["local>sanity-io/renovate-config"],
+  "encrypted": {
+    "npmToken": "wcFMA/xDdHCJBTolAQ//RsoBk1L3TvPVlsTAFhpG7gyTWjEZsWiwvqAEBYXfAhcqSuyGJOJPAlVG93qHJp/o8HHSM/4rs+oc7lQl8mCYnzkwGqHdYKpGsS91vWnCxCMf/eM/wgzZxfgzWLHkIo+fGMIpPJJxVSeJKETns/1+V5JeDVGZopkiwR+FicTVRsS0F0LnJ1JAE+m20jUZOrruLv3CF3mKRxfk4iz5SPAafyhLLmonAChOodEnfDe2x2UdUJFZgZBO+to0S5JGLzut1FDuZjikzcqVcUGG17SXFJXEdHTcy9kYz46nKBT5Qm1Dcrg9KE+AC5+hxc6UpnjLJjJAolbrui5hxaxKtN9YhaZeYtyz8Ng0x/UxskzeYpbZAUkhu+GBhVgPmpbDmZ4iZDbDKbkxaW0sJ5AfGFS9ehkCUwsX57x4v2EfCI4Ua8bqOEahFWBnHua0Xkxw6r9FPGJFvAaVkMLDL5fjDEWuKaBpv6pU4pwdbnqQ2rt+E7/CF4xzW89kPVaNK3ih68Ocnxtkrh+dRhv2KUND/IQSdNHWNYCbopgqqkJh/13pUYtjNxVIErM45ezyo5kRyE/uXK5LxlsgTdEDZfE/ieuiSFi/3d+uehy0HSzKW72WGrX10pgGGg4oX5p7o2j8vf3ss68Pr11hlJcxhZq0N6EkPsktbmCYNCXBn2sOh5tfh9jSfgGIFNNVsX2dPPP6Ve8gDbO/6VG6LAQk2wYxWEWHURocwPhHVpODXSqLbdrfqcuaidiadp54yNS8iWj8IOHLnjSlbvjAN7tBQT/rbUYus1HWkIOzfPouHTEHDym2N/5Qk4vydsG1cPuEm/ru30aC6hfRvusFonU9IT7vu1IX+g"
+  }
 }


### PR DESCRIPTION
Fixes the issue seen [here ](https://github.com/sanity-io/mutate/pull/13#issuecomment-2273238083):
```bash
Progress: resolved 1, reused 0, downloaded 0, added 0
/tmp/renovate/repos/github/sanity-io/mutate/examples/web:
 ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@sanity%2Fsanitype: Not Found - 404

This error happened while installing a direct dependency of /tmp/renovate/repos/github/sanity-io/mutate/examples/web

@sanity/sanitype is not in the npm registry, or you have no permission to fetch it.

No authorization header was set for the request.
```

The npm token is generated with granular access to just `@sanity/sanitype`:
![image](https://github.com/user-attachments/assets/9e488935-b5cb-474c-a061-33061ac891db)

It's encrypted with [Renovate's Encryption](https://app.renovatebot.com/encrypt) feature, scoped to `sanity-io` and the `mutate` repo:
![image](https://github.com/user-attachments/assets/9e1b6174-45f6-4a72-bba5-5cafc492a491)

All of these steps ensures that the encrypted token in this PR cannot:
- be decrypted by other tools than Renovate.
- if someone copies it and tries to use it on a different repo, on a different org, renovate will refuse to decrypt and use it since it's scoped.
- if Renovate itself is compromised and bad actors gain access to decrypt our token, then the npm token itself only has read access to install `@sanity/sanitype`, none of our other private packages can be installed, and it cannot be used to publish packages to our npm org.