### PR TITLE
feat: throw if attempting to apply mendoza patch on incorrect base revision

### DIFF
--- a/examples/web/App.tsx
+++ b/examples/web/App.tsx
@@ -53,6 +53,7 @@ import {
   TabPanel,
   Text,
 } from '@sanity/ui'
+import {type RawPatch} from 'mendoza'
 import {Fragment, type ReactNode, useCallback, useEffect, useState} from 'react'
 import {
   concatMap,
@@ -265,7 +266,9 @@ function observe(documentId: string) {
           : of({
               type: 'mutation' as const,
               transactionId: event.transactionId,
-              effects: event.effects!.apply,
+              effects: event.effects as {apply: RawPatch},
+              previousRev: event.previousRev!,
+              resultRev: event.resultRev!,
               mutations: event.mutations as SanityMutation[],
             }),
     ),

--- a/src/store/contentLakeStore.ts
+++ b/src/store/contentLakeStore.ts
@@ -16,7 +16,7 @@ import {
 
 import {decodeAll, type SanityMutation} from '../encoders/sanity'
 import {type Transaction} from '../mutations/types'
-import {applyMendozaPatch} from './datasets/applyMendoza'
+import {applyMutationEventEffects} from './datasets/applyMendoza'
 import {applyMutations} from './datasets/applyMutations'
 import {commit} from './datasets/commit'
 import {createDataset} from './datasets/createDataset'
@@ -118,10 +118,7 @@ export function createContentLakeStore(
             return EMPTY
           }
 
-          const newRemote = applyMendozaPatch(oldRemote, event.effects)
-          if (newRemote) {
-            newRemote._rev = event.transactionId
-          }
+          const newRemote = applyMutationEventEffects(oldRemote, event)
 
           const [rebasedStage, newLocal] = rebase(
             id,
@@ -140,6 +137,8 @@ export function createContentLakeStore(
             before: {remote: oldRemote, local: oldLocal},
             after: {remote: newRemote, local: newLocal},
             effects: event.effects,
+            previousRev: event.previousRev,
+            resultRev: event.resultRev,
             // overwritten below
             mutations: EMPTY_ARRAY,
           }

--- a/src/store/datasets/applyMendoza.ts
+++ b/src/store/datasets/applyMendoza.ts
@@ -13,7 +13,31 @@ function omitRev(document: SanityDocumentBase | undefined) {
 export function applyMendozaPatch(
   document: SanityDocumentBase | undefined,
   patch: RawPatch,
+  patchBaseRev: string,
 ): SanityDocumentBase | undefined {
+  if (patchBaseRev !== document?._rev) {
+    throw new Error(
+      'Invalid document revision. The provided patch is calculated from a different revision than the current document',
+    )
+  }
   const next = applyPatch(omitRev(document), patch)
   return next === null ? undefined : next
+}
+
+export function applyMutationEventEffects(
+  document: SanityDocumentBase | undefined,
+  event: {effects: {apply: RawPatch}; previousRev: string; resultRev: string},
+) {
+  if (!event.effects) {
+    throw new Error(
+      'Mutation event is missing effects. Is the listener set up with effectFormat=mendoza?',
+    )
+  }
+  const next = applyMendozaPatch(
+    document,
+    event.effects.apply,
+    event.previousRev,
+  )
+  // next will be undefined in case of deletion
+  return next ? {...next, _rev: event.resultRev} : undefined
 }

--- a/src/store/sanityApiTypes.ts
+++ b/src/store/sanityApiTypes.ts
@@ -1,3 +1,5 @@
+import {type RawPatch} from 'mendoza'
+
 import {type SanityMutation} from '../encoders/sanity'
 import {type SanityDocumentBase} from '../mutations/types'
 
@@ -29,7 +31,7 @@ export type SanityMutationEvent = {
   resultRev?: string
   result?: SanityDocumentBase
   previous?: SanityDocumentBase | null
-  effects?: {apply: unknown[]; revert: unknown[]}
+  effects?: {apply: RawPatch}
   timestamp: string
   transactionId: string
   transition: 'update' | 'appear' | 'disappear'

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -14,8 +14,10 @@ export interface ListenerSyncEvent {
 export interface ListenerMutationEvent {
   type: 'mutation'
   transactionId: string
-  effects: Required<SanityMutationEvent>['effects']['apply']
-  mutations: Required<SanityMutationEvent>['mutations']
+  resultRev: string
+  previousRev: string
+  effects: Required<SanityMutationEvent>['effects']
+  mutations: Required<SanityMutationEvent['mutations']>
 }
 export interface ListenerReconnectEvent {
   type: 'reconnect'
@@ -60,7 +62,9 @@ export interface RemoteMutationEvent {
     local: SanityDocumentBase | undefined
     remote: SanityDocumentBase | undefined
   }
-  effects: RawPatch
+  effects: {apply: RawPatch}
+  previousRev: string
+  resultRev: string
   mutations: Mutation[]
   rebasedStage: MutationGroup[]
 }


### PR DESCRIPTION
Since mendoza patches are extremely sensitive to being applied in the correct order, this PR implements safeguarding that makes it harder to accidentally make a mistake and apply a patch on the wrong revision. You will now be required to pass the base/previous revision when applying a patch, and an error will be thrown if the revision of the document doesn't match the provided base revision.

This mean that in order to be allowed to apply a patch you'll have to have the previous revision at hand. When applying patches received from listener events, the `previousRev` will always be present on the event, so it will just be a matter of passing it along when applying the patch.

There _might_ be cases where it becomes cumbersome to have to provide the previous revision. I'm not aware of any at this point, but we could consider adding an `unsafeApplyMendozaPatch()` in the future if we want.