### PR TITLE
feat: add support for array remove operation

### DIFF
--- a/examples/ts/apply-patch-mutation.ts
+++ b/examples/ts/apply-patch-mutation.ts
@@ -7,6 +7,7 @@ import {
   insertBefore,
   patch,
   prepend,
+  remove,
   setIfMissing,
   unassign,
   unset,
@@ -17,6 +18,7 @@ const document = {
   _id: 'test',
   _type: 'foo',
   unsetme: 'yes',
+  someArray: [{_key: 'foo'}, {_key: 'bar'}],
   unassignme: 'please',
   assigned: {existing: 'prop'},
 } as const
@@ -30,6 +32,7 @@ const patches = patch('test', [
   at('cities', insertAfter(['Chicago'], 1)),
   at('cities', insertBefore(['Raleigh'], 3)),
   at('unsetme', unset()),
+  at('someArray', remove({_key: 'foo'})),
   at([], unassign(['unassignme'])),
   at('hmmm', assign({other: 'value'})),
 ])

--- a/examples/web/lib/mutate-formatter/react/components/FormatPatchMutation.tsx
+++ b/examples/web/lib/mutate-formatter/react/components/FormatPatchMutation.tsx
@@ -125,6 +125,13 @@ function FormatOp(props: {op: Operation}) {
       </Text>
     )
   }
+  if (op.type === 'remove') {
+    return (
+      <Text size={1} weight="semibold">
+        {op.type} ({formatReferenceItem(op.referenceItem)}))
+      </Text>
+    )
+  }
   // @ts-expect-error all cases are covered
   throw new Error(`Invalid operation type: ${op.type}`)
 }

--- a/src/apply/patch/__test__/array.test.ts
+++ b/src/apply/patch/__test__/array.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from 'vitest'
 
-import {insert, replace} from '../../../mutations/operations/creators'
+import {insert, remove, replace} from '../../../mutations/operations/creators'
 import {applyOp} from '../applyOp'
 
 test('replace on item', () => {
@@ -150,4 +150,38 @@ test('insert relative to nonexisting keyed path elements', () => {
   expect(() =>
     applyOp(insert(['INSERT!'], 'after', {_key: 'foo'}), []),
   ).toThrow()
+})
+
+test('remove item at key', () => {
+  expect(
+    applyOp(remove({_key: 'foo'}), [
+      {_key: 'one'},
+      {_key: 'foo'},
+      {_key: 'two'},
+    ]),
+  ).toEqual([{_key: 'one'}, {_key: 'two'}])
+
+  expect(
+    applyOp(remove({_key: 'foo'}), [{_key: 'foo'}, {_key: 'two'}]),
+  ).toEqual([{_key: 'two'}])
+  expect(
+    applyOp(remove({_key: 'foo'}), [{_key: 'one'}, {_key: 'foo'}]),
+  ).toEqual([{_key: 'one'}])
+
+  expect(applyOp(remove({_key: 'foo'}), [{_key: 'foo'}])).toEqual([])
+})
+
+test('remove item at index', () => {
+  expect(
+    applyOp(remove(1), [{_key: 'one'}, {_key: 'foo'}, {_key: 'two'}]),
+  ).toEqual([{_key: 'one'}, {_key: 'two'}])
+
+  expect(applyOp(remove(0), [{_key: 'foo'}, {_key: 'two'}])).toEqual([
+    {_key: 'two'},
+  ])
+  expect(applyOp(remove(1), [{_key: 'one'}, {_key: 'foo'}])).toEqual([
+    {_key: 'one'},
+  ])
+
+  expect(applyOp(remove(0), [{_key: 'foo'}])).toEqual([])
 })

--- a/src/apply/patch/operations/array.ts
+++ b/src/apply/patch/operations/array.ts
@@ -2,6 +2,7 @@ import {
   type InsertOp,
   type KeyedPathElement,
   type RelativePosition,
+  type RemoveOp,
   type ReplaceOp,
   type TruncateOp,
   type UpsertOp,
@@ -86,6 +87,20 @@ export function replace<
     throw new Error(`Found no matching array element to replace`)
   }
   return splice(currentValue, index, op.items.length, op.items)
+}
+export function remove<
+  O extends RemoveOp<number | KeyedPathElement>,
+  CurrentValue extends unknown[],
+>(op: O, currentValue: CurrentValue) {
+  if (!Array.isArray(currentValue)) {
+    throw new TypeError('Cannot apply "remove()" on non-array value')
+  }
+
+  const index = findTargetIndex(currentValue, op.referenceItem)
+  if (index === null) {
+    throw new Error(`Found no matching array element to replace`)
+  }
+  return splice(currentValue, index, 1, [])
 }
 
 export function truncate<O extends TruncateOp, CurrentValue extends unknown[]>(

--- a/src/apply/patch/typings/applyOp.ts
+++ b/src/apply/patch/typings/applyOp.ts
@@ -89,7 +89,7 @@ export type InsertAtIndex<
   NormalizeIndex<Index, ArrayLength<Current>>
 >
 
-export type DropFirst<Array extends any> = Array extends [
+export type DropFirst<Array extends unknown[]> = Array extends [
   infer Head,
   ...infer Rest,
 ]

--- a/src/apply/patch/typings/applyOp.ts
+++ b/src/apply/patch/typings/applyOp.ts
@@ -8,6 +8,7 @@ import {
   type InsertOp,
   type KeyedPathElement,
   type Operation,
+  type RemoveOp,
   type ReplaceOp,
   type SetIfMissingOp,
   type SetOp,
@@ -88,6 +89,36 @@ export type InsertAtIndex<
   NormalizeIndex<Index, ArrayLength<Current>>
 >
 
+export type DropFirst<Array extends any> = Array extends [
+  infer Head,
+  ...infer Rest,
+]
+  ? Rest
+  : []
+
+export type _RemoveAtIndex<Current extends unknown[], Index extends number> =
+  Between<Index, 0, ArrayLength<Current>> extends true
+    ? Call<Tuples.SplitAt<Index>, Current> extends [infer Head, infer Tail]
+      ? Head extends AnyArray
+        ? Tail extends AnyArray
+          ? [
+              ...(Head extends never[] ? [] : Head),
+              ...(Tail extends never[]
+                ? []
+                : Tail extends unknown[]
+                  ? DropFirst<Tail>
+                  : Tail),
+            ]
+          : never
+        : never
+      : never
+    : Current
+
+export type RemoveAtIndex<
+  Current extends unknown[],
+  Index extends number,
+> = _RemoveAtIndex<Current, NormalizeIndex<Index, ArrayLength<Current>>>
+
 export type ArrayInsert<
   Current extends unknown[],
   Items extends unknown[],
@@ -100,6 +131,16 @@ export type ArrayInsert<
       ? InsertAtIndex<Current, Items, Pos, Ref>
       : (E | ArrayElement<Items>)[]
   : Current
+
+export type ArrayRemove<
+  Current extends unknown[],
+  Ref extends number | KeyedPathElement,
+> = number extends Ref
+  ? Current
+  : Ref extends number
+    ? RemoveAtIndex<Current, Ref>
+    : // todo: look up index of item with _key
+      Current
 
 export type Assign<Current, Attrs> = {
   [K in keyof Attrs | keyof Current]: K extends keyof Attrs
@@ -155,4 +196,9 @@ export type ApplyOp<O extends Operation, Current> = Current extends never
                       }
                     : O extends DiffMatchPatchOp
                       ? string
-                      : never
+                      : O extends RemoveOp<infer Ref>
+                        ? Current extends AnyArray<unknown>
+                          ? ArrayRemove<NormalizeReadOnlyArray<Current>, Ref>
+                          : Current
+                        : // fallback
+                          Current

--- a/src/encoders/compact/encode.ts
+++ b/src/encoders/compact/encode.ts
@@ -105,6 +105,9 @@ function encodePatchMutation(
   if (op.type === 'truncate') {
     return ['patch', 'truncate', id, path, [op.startIndex, op.endIndex]]
   }
+  if (op.type === 'remove') {
+    return ['patch', 'remove', id, path, [encodeItemRef(op.referenceItem)]]
+  }
   // @ts-expect-error all cases are covered
   throw new Error(`Invalid operation type: ${op.type}`)
 }

--- a/src/encoders/compact/types.ts
+++ b/src/encoders/compact/types.ts
@@ -86,6 +86,14 @@ export type ReplaceMutation = [
   [ItemRef, AnyArray],
   RevisionLock?,
 ]
+export type RemoveMutation = [
+  'patch',
+  'remove',
+  Id,
+  CompactPath,
+  [ItemRef],
+  RevisionLock?,
+]
 export type SetMutation = ['patch', 'set', Id, CompactPath, any, RevisionLock?]
 export type SetIfMissingMutation = [
   'patch',
@@ -118,6 +126,7 @@ export type CompactPatchMutation =
   | AssignMutation
   | UnassignMutation
   | ReplaceMutation
+  | RemoveMutation
 
 export type CompactMutation<Doc> =
   | DeleteMutation

--- a/src/encoders/sanity/encode.ts
+++ b/src/encoders/sanity/encode.ts
@@ -113,6 +113,11 @@ function patchToSanity(patch: NodePatch) {
       },
     }
   }
+  if (op.type === 'remove') {
+    return {
+      unset: [stringifyPath(path.concat(op.referenceItem))],
+    }
+  }
   //@ts-expect-error all cases should be covered
   throw new Error(`Unknown operation type ${op.type}`)
 }

--- a/src/formatters/compact.ts
+++ b/src/formatters/compact.ts
@@ -90,6 +90,9 @@ function formatPatchMutation(patch: NodePatch<any>): string {
   if (op.type === 'truncate') {
     return [path, `truncate(${op.startIndex}, ${op.endIndex}`].join(': ')
   }
+  if (op.type === 'remove') {
+    return [path, `remove(${encodeItemRef(op.referenceItem)})`].join(': ')
+  }
   // @ts-expect-error all cases are covered
   throw new Error(`Invalid operation type: ${op.type}`)
 }

--- a/src/mutations/operations/creators.ts
+++ b/src/mutations/operations/creators.ts
@@ -13,6 +13,7 @@ import {
   type InsertOp,
   type KeyedPathElement,
   type RelativePosition,
+  type RemoveOp,
   type ReplaceOp,
   type SetIfMissingOp,
   type SetOp,
@@ -132,6 +133,18 @@ export function replace<
     type: 'replace',
     referenceItem,
     items: arrify(items) as Items,
+  }
+}
+
+/*
+  Remove an item from an array by either key or index
+ */
+export function remove<ReferenceItem extends Index | KeyedPathElement>(
+  referenceItem: ReferenceItem,
+): RemoveOp<ReferenceItem> {
+  return {
+    type: 'remove',
+    referenceItem,
   }
 }
 

--- a/src/mutations/operations/types.ts
+++ b/src/mutations/operations/types.ts
@@ -45,6 +45,12 @@ export type TruncateOp = {
   startIndex: number
   endIndex?: number
 }
+
+export type RemoveOp<ReferenceItem extends Index | KeyedPathElement> = {
+  type: 'remove'
+  referenceItem: ReferenceItem
+}
+
 export type ReplaceOp<
   Items extends AnyArray,
   ReferenceItem extends Index | KeyedPathElement,
@@ -90,5 +96,6 @@ export type ArrayOp =
   | UpsertOp<AnyArray, RelativePosition, Index | KeyedPathElement>
   | ReplaceOp<AnyArray, Index | KeyedPathElement>
   | TruncateOp
+  | RemoveOp<Index | KeyedPathElement>
 
 export type PrimitiveOp = AnyOp | StringOp | NumberOp


### PR DESCRIPTION
Adds support for `remove()` operation on arrays

Usage: `at('some.array.path', remove({_key: 'foo'}))`

See tests [here](https://github.com/sanity-io/mutate/commit/b99d8eadb43b45eb2732dd41155e4bc8ebcb0165#diff-afc4fb5e0472a526d4de50ea219460bd34e231f7306098cb0241185993328ae1R155-R187)
See example [here](https://github.com/sanity-io/mutate/blob/4c3ea6b934ad87c50836c99b0b85ae1fd9e62863/examples/ts/apply-patch-mutation.ts#L35)
