### PR TITLE
fix: return correct value on `applyInArray` assumed noop

### DIFF
--- a/src/apply/patch/__test__/applyNodePatch.test.ts
+++ b/src/apply/patch/__test__/applyNodePatch.test.ts
@@ -42,7 +42,12 @@ describe('set', () => {
     const patch = at('objects[_key=="first"].title', set('first'))
 
     const result = applyNodePatch(patch, document)
-
+    expect(result).toEqual({
+      objects: [
+        {_key: 'first', title: 'first'},
+        {_key: 'second', title: 'second'},
+      ],
+    })
     assertType<{_key: string; title: string}[]>(result.objects)
   })
 })

--- a/src/apply/patch/__test__/applyNodePatch.test.ts
+++ b/src/apply/patch/__test__/applyNodePatch.test.ts
@@ -30,6 +30,21 @@ describe('set', () => {
 
     assertType<{_key: string; title: string}[]>(result.objects)
   })
+
+  test('set same value inside object array', () => {
+    const document = {
+      objects: [
+        {_key: 'first', title: 'first'},
+        {_key: 'second', title: 'second'},
+      ],
+    }
+
+    const patch = at('objects[_key=="first"].title', set('first'))
+
+    const result = applyNodePatch(patch, document)
+
+    assertType<{_key: string; title: string}[]>(result.objects)
+  })
 })
 
 describe('setIfMissing', () => {

--- a/src/apply/patch/applyNodePatch.ts
+++ b/src/apply/patch/applyNodePatch.ts
@@ -41,7 +41,7 @@ function applyAtPath<P extends Path, O extends Operation, T>(
   const [head, ...tail] = path
 
   if (isArrayElement(head) && Array.isArray(value)) {
-    return applyInArray(head, tail, op, value)
+    return applyInArray(head, tail, op, value) as any
   }
 
   if (isPropertyElement(head) && isObject(value)) {
@@ -106,7 +106,7 @@ function applyInArray<T>(
   // a noop and don't modify our value. If we get a new value back, we return a
   // new array with the modified item replaced
   return patchedItem === current
-    ? current
+    ? value
     : splice(value, index, 1, [patchedItem])
 }
 


### PR DESCRIPTION
I believe the previous value returned by `applyInArray` was incorrect when the result of applying returned the existing item.

The value of `current` in `applyInArray` refers to the array item. Returning it means the array was being replaced with a single item. It should instead return `value` which is the array, not the array item, if the patched item was unmodified.