### PR TITLE
fix: stop inlining lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/mutate",
-  "version": "0.10.0",
+  "version": "0.10.1-lodash.0",
   "description": "Experimental toolkit for working with Sanity mutations in JavaScript & TypeScript",
   "keywords": [
     "sanity",
@@ -92,6 +92,7 @@
     "@sanity/client": "^6.21.1",
     "@sanity/diff-match-patch": "^3.1.1",
     "hotscript": "^1.0.13",
+    "lodash": "^4.17.21",
     "mendoza": "^3.0.7",
     "nanoid": "^5.0.7",
     "rxjs": "^7.8.1"
@@ -113,7 +114,6 @@
     "eslint-plugin-react-hooks": "catalog:",
     "eslint-plugin-simple-import-sort": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
-    "lodash": "^4.17.21",
     "npm-run-all2": "^5.0.0",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       hotscript:
         specifier: ^1.0.13
         version: 1.0.13
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       mendoza:
         specifier: ^3.0.7
         version: 3.0.7
@@ -117,9 +120,6 @@ importers:
       eslint-plugin-unused-imports:
         specifier: 'catalog:'
         version: 3.2.0(@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2
@@ -1803,6 +1803,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:


### PR DESCRIPTION
We're accidentally inlining lodash, since it's in `devDependencies` when it should be in `dependencies`:

[![screenshot](https://github.com/user-attachments/assets/cf8a3f7e-7474-4870-9dfe-512f4e924f98)](https://bundlephobia.com/package/@sanity/mutate@0.10.0)

[Diff showing its impact](https://npmdiff.dev/%40sanity%2Fmutate/0.10.0/0.10.1-lodash.0/package/dist/_unstable_store.js/)