### PR TITLE
chore(example): upgrade @sanity/sanitype dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>sanity-io/renovate-config"],
-  "encrypted": {
-    "npmToken": "wcFMA/xDdHCJBTolAQ//RsoBk1L3TvPVlsTAFhpG7gyTWjEZsWiwvqAEBYXfAhcqSuyGJOJPAlVG93qHJp/o8HHSM/4rs+oc7lQl8mCYnzkwGqHdYKpGsS91vWnCxCMf/eM/wgzZxfgzWLHkIo+fGMIpPJJxVSeJKETns/1+V5JeDVGZopkiwR+FicTVRsS0F0LnJ1JAE+m20jUZOrruLv3CF3mKRxfk4iz5SPAafyhLLmonAChOodEnfDe2x2UdUJFZgZBO+to0S5JGLzut1FDuZjikzcqVcUGG17SXFJXEdHTcy9kYz46nKBT5Qm1Dcrg9KE+AC5+hxc6UpnjLJjJAolbrui5hxaxKtN9YhaZeYtyz8Ng0x/UxskzeYpbZAUkhu+GBhVgPmpbDmZ4iZDbDKbkxaW0sJ5AfGFS9ehkCUwsX57x4v2EfCI4Ua8bqOEahFWBnHua0Xkxw6r9FPGJFvAaVkMLDL5fjDEWuKaBpv6pU4pwdbnqQ2rt+E7/CF4xzW89kPVaNK3ih68Ocnxtkrh+dRhv2KUND/IQSdNHWNYCbopgqqkJh/13pUYtjNxVIErM45ezyo5kRyE/uXK5LxlsgTdEDZfE/ieuiSFi/3d+uehy0HSzKW72WGrX10pgGGg4oX5p7o2j8vf3ss68Pr11hlJcxhZq0N6EkPsktbmCYNCXBn2sOh5tfh9jSfgGIFNNVsX2dPPP6Ve8gDbO/6VG6LAQk2wYxWEWHURocwPhHVpODXSqLbdrfqcuaidiadp54yNS8iWj8IOHLnjSlbvjAN7tBQT/rbUYus1HWkIOzfPouHTEHDym2N/5Qk4vydsG1cPuEm/ru30aC6hfRvusFonU9IT7vu1IX+g"
-  }
+  "extends": ["local>sanity-io/renovate-config"]
 }

--- a/examples/web/lib/form/FormNode.tsx
+++ b/examples/web/lib/form/FormNode.tsx
@@ -9,6 +9,7 @@ import {
   getInstanceName,
   type Infer,
   isDocumentSchema,
+  isNeverSchema,
   isObjectSchema,
   isObjectUnionSchema,
   isOptionalSchema,
@@ -74,7 +75,9 @@ function resolveNode<Schema extends SanityType>(
 
   if (isObjectUnionSchema(schema)) {
     const type = value?._type
-    const valueType = schema.union.find(ut => getInstanceName(ut) === type)!
+    const valueType = schema.union.find(
+      ut => !isNeverSchema(ut) && getInstanceName(ut) === type,
+    )!
     const typeForm = (
       (form as ObjectUnionFormDef<SanityTypedObject>).types as any
     )[type]

--- a/examples/web/lib/form/inputs/UnionInput.tsx
+++ b/examples/web/lib/form/inputs/UnionInput.tsx
@@ -2,6 +2,7 @@ import {EllipsisVerticalIcon, TransferIcon, TrashIcon} from '@sanity/icons'
 import {assign, at, set, unset} from '@sanity/mutate'
 import {
   getInstanceName,
+  isNeverSchema,
   isObjectSchema,
   type ObjectUnionFormDef,
   pickDeep,
@@ -39,7 +40,9 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
   const valueTypeName = value?._type
 
   const currentSchema = valueTypeName
-    ? schema.union.find(ut => getInstanceName(ut) === valueTypeName)
+    ? schema.union.find(
+        ut => !isNeverSchema(ut) && getInstanceName(ut) === valueTypeName,
+      )
     : undefined
 
   const handlePatch = useCallback(
@@ -56,7 +59,7 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
   const handleTurnInto = useCallback(
     (nextTypeName: string) => {
       const nextSchema = schema.union.find(
-        ut => getInstanceName(ut) === nextTypeName,
+        ut => !isNeverSchema(ut) && getInstanceName(ut) === nextTypeName,
       )
       if (!nextSchema) {
         throw new Error(`No valid union type named ${nextTypeName}.`)
@@ -74,7 +77,7 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
   const handleSelectType = useCallback(
     (nextTypeName: string) => {
       const nextSchema = schema.union.find(
-        ut => getInstanceName(ut) === nextTypeName,
+        ut => !isNeverSchema(ut) && getInstanceName(ut) === nextTypeName,
       )
       if (!nextSchema) {
         throw new Error(`No valid union type named ${nextTypeName}.`)
@@ -99,7 +102,7 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
       <Select onChange={e => handleSelectType(e.currentTarget.value)}>
         <option value="">Select type</option>
         {schema.union.map(ut => {
-          const name = getInstanceName(ut)
+          const name = !isNeverSchema(ut) && getInstanceName(ut)
           if (!name || !(name in form.types)) {
             throw new Error(`No form definition found for type ${name}`)
           }
@@ -143,6 +146,9 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
                     text="Turn into…"
                   >
                     {otherTypes.map(type => {
+                      if (isNeverSchema(type)) {
+                        return null
+                      }
                       const sharedProperties = intersection(
                         Object.keys(type.shape),
                         Object.keys(currentSchema.shape),

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -12,7 +12,7 @@
     "@sanity/client": "^6.21.1",
     "@sanity/icons": "^3.3.1",
     "@sanity/mutate": "workspace:",
-    "@sanity/sanitype": "^0.4.0",
+    "@sanity/sanitype": "^0.6.1",
     "@sanity/ui": "^2.8.8",
     "dataloader": "^2.2.2",
     "groq-js": "^1.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,8 +193,8 @@ importers:
         specifier: 'workspace:'
         version: link:../..
       '@sanity/sanitype':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.6.1
+        version: 0.6.1
       '@sanity/ui':
         specifier: ^2.8.8
         version: 2.8.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1224,12 +1224,12 @@ packages:
     peerDependencies:
       prettier: ^3.2.5
 
-  '@sanity/sanitype@0.4.0':
-    resolution: {integrity: sha512-iNqtX099vddRox1a3QzuIbhfiG3A/eYN7LLK8ZU12iQM/IltMs1t4rUiS1su7CGJ2DaLLdlZ7F8GAILfk8qFXQ==}
+  '@sanity/sanitype@0.6.1':
+    resolution: {integrity: sha512-pujGR04N1xGjB6Dk7FkuSDnAj8cBdQ88TY8ibF474Xzgoz89LC8bQLtfE+2RY4xunNMbI4lvXVbhQ71Iq63obg==}
     engines: {node: '>= 18'}
 
-  '@sanity/types@3.61.0':
-    resolution: {integrity: sha512-JXJ7hb615/jj929J5p6g7i0GTP5USmshFOKyrLBib98lEufQZjjzUKh/Tx1MOqk/CSYWkRkl/qY96/hc9FnN4A==}
+  '@sanity/types@3.63.0':
+    resolution: {integrity: sha512-d7Qbd07mzbvI6bEfb4j7LnDH5dAf5nwEyYPj+e8tHjlPYzyoutKQ5wmTU8rNqTmg4PiuvNYyDo6zWcEVrUW8Vw==}
 
   '@sanity/ui@2.8.8':
     resolution: {integrity: sha512-LeYpcng9fakvwgCtAV4b/2koCsm7TTDQNwK+r2MnVghH23ln0iblvBdO4+T1Q10E+m2Vr2dcy3+HErdTu8f8Ag==}
@@ -4284,14 +4284,14 @@ snapshots:
       prettier: 3.3.3
       prettier-plugin-packagejson: 2.5.3(prettier@3.3.3)
 
-  '@sanity/sanitype@0.4.0':
+  '@sanity/sanitype@0.6.1':
     dependencies:
-      '@sanity/types': 3.61.0
+      '@sanity/types': 3.63.0
       date-fns: 4.1.0
     transitivePeerDependencies:
       - debug
 
-  '@sanity/types@3.61.0':
+  '@sanity/types@3.63.0':
     dependencies:
       '@sanity/client': 6.22.3
       '@types/react': 18.3.11


### PR DESCRIPTION
`@sanity/sanitype` is now public, so we can also remove the npm token from this repo 🙌🏼 