### PR TITLE
chore(deps): upgrade sanitype to 0.6.2

### DIFF
--- a/examples/web/lib/form/inputs/UnionInput.tsx
+++ b/examples/web/lib/form/inputs/UnionInput.tsx
@@ -2,7 +2,6 @@ import {EllipsisVerticalIcon, TransferIcon, TrashIcon} from '@sanity/icons'
 import {assign, at, set, unset} from '@sanity/mutate'
 import {
   getInstanceName,
-  isNeverSchema,
   isObjectSchema,
   type ObjectUnionFormDef,
   pickDeep,
@@ -40,9 +39,7 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
   const valueTypeName = value?._type
 
   const currentSchema = valueTypeName
-    ? schema.union.find(
-        ut => !isNeverSchema(ut) && getInstanceName(ut) === valueTypeName,
-      )
+    ? schema.union.find(ut => getInstanceName(ut) === valueTypeName)
     : undefined
 
   const handlePatch = useCallback(
@@ -59,7 +56,7 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
   const handleTurnInto = useCallback(
     (nextTypeName: string) => {
       const nextSchema = schema.union.find(
-        ut => !isNeverSchema(ut) && getInstanceName(ut) === nextTypeName,
+        ut => getInstanceName(ut) === nextTypeName,
       )
       if (!nextSchema) {
         throw new Error(`No valid union type named ${nextTypeName}.`)
@@ -77,7 +74,7 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
   const handleSelectType = useCallback(
     (nextTypeName: string) => {
       const nextSchema = schema.union.find(
-        ut => !isNeverSchema(ut) && getInstanceName(ut) === nextTypeName,
+        ut => getInstanceName(ut) === nextTypeName,
       )
       if (!nextSchema) {
         throw new Error(`No valid union type named ${nextTypeName}.`)
@@ -102,7 +99,7 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
       <Select onChange={e => handleSelectType(e.currentTarget.value)}>
         <option value="">Select type</option>
         {schema.union.map(ut => {
-          const name = !isNeverSchema(ut) && getInstanceName(ut)
+          const name = getInstanceName(ut)
           if (!name || !(name in form.types)) {
             throw new Error(`No form definition found for type ${name}`)
           }
@@ -146,9 +143,6 @@ export function UnionInput(props: InputProps<SanityObjectUnion>) {
                     text="Turn into…"
                   >
                     {otherTypes.map(type => {
-                      if (isNeverSchema(type)) {
-                        return null
-                      }
                       const sharedProperties = intersection(
                         Object.keys(type.shape),
                         Object.keys(currentSchema.shape),

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -12,7 +12,7 @@
     "@sanity/client": "^6.21.1",
     "@sanity/icons": "^3.3.1",
     "@sanity/mutate": "workspace:",
-    "@sanity/sanitype": "^0.6.1",
+    "@sanity/sanitype": "^0.6.2",
     "@sanity/ui": "^2.8.8",
     "dataloader": "^2.2.2",
     "groq-js": "^1.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,8 +193,8 @@ importers:
         specifier: 'workspace:'
         version: link:../..
       '@sanity/sanitype':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
       '@sanity/ui':
         specifier: ^2.8.8
         version: 2.8.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1224,8 +1224,8 @@ packages:
     peerDependencies:
       prettier: ^3.2.5
 
-  '@sanity/sanitype@0.6.1':
-    resolution: {integrity: sha512-pujGR04N1xGjB6Dk7FkuSDnAj8cBdQ88TY8ibF474Xzgoz89LC8bQLtfE+2RY4xunNMbI4lvXVbhQ71Iq63obg==}
+  '@sanity/sanitype@0.6.2':
+    resolution: {integrity: sha512-Gy2pjphz399HpJY5UxBLWY6/Yt89rLzNpkI9+Cgv8qdEmVlPxXQ/3eEs1y3JHWxp1fFHXNetobIIlIS9+wFv4Q==}
     engines: {node: '>= 18'}
 
   '@sanity/types@3.63.0':
@@ -4284,7 +4284,7 @@ snapshots:
       prettier: 3.3.3
       prettier-plugin-packagejson: 2.5.3(prettier@3.3.3)
 
-  '@sanity/sanitype@0.6.1':
+  '@sanity/sanitype@0.6.2':
     dependencies:
       '@sanity/types': 3.63.0
       date-fns: 4.1.0


### PR DESCRIPTION
As of sanitype v0.6.2, _never_-types will be excluded from unions, so `isNeverType(type)` guards like [this](https://github.com/sanity-io/mutate/compare/upgrade-sanitype?expand=1#diff-c3924215d6cc36ce48257ba9b9572e99d6e1f6d3ee386a62f10ce6aaa8de1ebcL44) is no longer needed