### PR TITLE
chore: ignore visual-editing builds (for now)

### DIFF
--- a/examples/visual-editing/.vercel-ignore
+++ b/examples/visual-editing/.vercel-ignore
@@ -1,0 +1,1 @@
+The presence of this file will skip vercel builds. Remove to build.


### PR DESCRIPTION
This adds a dummy file that we use with "Ignore build step"-config to skip vercel deployments until #29 lands. I tried checking for mere presence of the `examples/visual-editing` folder (using `if [ -d examples/visual-editing ]; then echo 0; else echo 1; fi`), but Vercel would still fail the deployment when it couldn't find the root directory later on.