### PR TITLE
chore: correct readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fetch(`https://${projectId}.api.sanity.io/v2023-08-01/data/mutate/${dataset}`, {
   headers: {
     'Content-Type': 'application/json',
   },
-  body: JSON.stringify(SanityEncoder.encode(mutations)),
+  body: JSON.stringify(SanityEncoder.encodeAll(mutations)),
 })
   .then(response => response.json())
   .then(result => console.log(result))


### PR DESCRIPTION
### Description

Very small tweak, but i think the example in the readme is wrong, because `mutations` in an array, i think it should be using `mutateAll` – I had a type error with the former & ended up looking at the tests to figure it out since the types are non-trivial 😄 