### PR TITLE
fix(types): use explicit return type for sanity encoder

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
+  dts: 'rolldown',
   extract: {
     rules: {
       'ae-missing-release-tag': 'off',


### PR DESCRIPTION
### Description

api-extractor generates invalid `d.ts` output and adds imports that goes out of the dist/module boundary (see example here: https://app.unpkg.com/@sanity/mutate@0.12.5/files/dist/index.d.ts)

Switching to rolldown for dts build fixes it 🙌🏼 

### What to review
- Also added some explicit return value typing that prevents output types from becoming `any` in certain cases.

### Testing
Existing tests/type check should be enough.
