### PR TITLE
feat: add support for insertIfMissing patch

### DIFF
--- a/examples/web/lib/mutate-formatter/react/components/FormatPatchMutation.tsx
+++ b/examples/web/lib/mutate-formatter/react/components/FormatPatchMutation.tsx
@@ -94,7 +94,11 @@ function FormatOp(props: {op: Operation}) {
       </Inline>
     )
   }
-  if (op.type === 'insert' || op.type === 'upsert') {
+  if (
+    op.type === 'insert' ||
+    op.type === 'upsert' ||
+    op.type === 'insertIfMissing'
+  ) {
     return (
       <>
         <Text size={1} weight="semibold">

--- a/src/apply/patch/__test__/insertIfMissing.test.ts
+++ b/src/apply/patch/__test__/insertIfMissing.test.ts
@@ -1,0 +1,109 @@
+import {expect, test} from 'vitest'
+
+import {insertIfMissing} from '../../../mutations/operations/creators'
+import {applyOp} from '../applyOp'
+
+test('insert or update relative to keyed path elements', () => {
+  const arr = [{_key: 'foo', value: 'foo'}]
+  expect(
+    applyOp(
+      insertIfMissing([{_key: 'hello', value: 'bar'}], 'before', {_key: 'foo'}),
+      arr,
+    ),
+  ).toEqual([
+    {_key: 'hello', value: 'bar'},
+    {_key: 'foo', value: 'foo'},
+  ])
+  expect(
+    applyOp(
+      insertIfMissing([{_key: 'hello', value: 'bar'}], 'after', {_key: 'foo'}),
+      arr,
+    ),
+  ).toEqual([
+    {_key: 'foo', value: 'foo'},
+    {_key: 'hello', value: 'bar'},
+  ])
+})
+
+test('insertIfMissing when items doesnt exist', () => {
+  expect(
+    applyOp(insertIfMissing([{_key: 'new', value: 'bar'}], 'before', 0), [
+      {_key: 'hello', value: 'bar'},
+      {_key: 'foo', value: 'foo'},
+    ]),
+  ).toEqual([
+    {_key: 'new', value: 'bar'},
+    {_key: 'hello', value: 'bar'},
+    {_key: 'foo', value: 'foo'},
+  ])
+
+  expect(
+    applyOp(insertIfMissing([{_key: 'new', value: 'bar'}], 'after', -1), [
+      {_key: 'hello', value: 'bar'},
+      {_key: 'foo', value: 'foo'},
+    ]),
+  ).toEqual([
+    {_key: 'hello', value: 'bar'},
+    {_key: 'foo', value: 'foo'},
+    {_key: 'new', value: 'bar'},
+  ])
+
+  expect(
+    applyOp(
+      insertIfMissing([{_key: 'hello', value: 'bar'}], 'after', {_key: 'foo'}),
+      [{_key: 'foo', value: 'foo'}],
+    ),
+  ).toEqual([
+    {_key: 'foo', value: 'foo'},
+    {_key: 'hello', value: 'bar'},
+  ])
+})
+
+test('insertIfMissing when item exist', () => {
+  expect(
+    applyOp(insertIfMissing([{_key: 'foo', value: 'INITIAL'}], 'before', 0), [
+      {_key: 'hello', value: 'bar'},
+      {_key: 'foo', value: 'foo'},
+    ]),
+  ).toEqual([
+    {_key: 'hello', value: 'bar'},
+    {_key: 'foo', value: 'foo'},
+  ])
+})
+
+test('insertIfMissing when items exist', () => {
+  expect(
+    applyOp(
+      insertIfMissing(
+        [
+          {_key: 'existing', value: 'INITIAL'},
+          {_key: 'new', value: 'INITIAL'},
+        ],
+        'before',
+        0,
+      ),
+      [
+        {_key: 'existing', value: 'bar'},
+        {_key: 'foo', value: 'foo'},
+      ],
+    ),
+  ).toEqual([
+    {_key: 'new', value: 'INITIAL'},
+    {_key: 'existing', value: 'bar'},
+    {_key: 'foo', value: 'foo'},
+  ])
+})
+
+test('insert relative to nonexisting keyed path elements', () => {
+  const arr = [{_key: 'foo', value: 'foo'}]
+  expect(() =>
+    applyOp(
+      insertIfMissing([{_key: 'hello', value: 'bar'}], 'before', {
+        _key: 'doesntexist',
+      }),
+      arr,
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Found no matching array element to insert before]`,
+  )
+})

--- a/src/apply/patch/operations/array.ts
+++ b/src/apply/patch/operations/array.ts
@@ -1,4 +1,5 @@
 import {
+  type InsertIfMissingOp,
   type InsertOp,
   type KeyedPathElement,
   type RelativePosition,
@@ -71,6 +72,41 @@ export function upsert<
       position: op.position,
     },
     next,
+  )
+}
+export function insertIfMissing<
+  O extends InsertIfMissingOp<
+    {_key: string}[],
+    RelativePosition,
+    KeyedPathElement
+  >,
+  CurrentValue extends unknown[],
+>(op: O, currentValue: CurrentValue) {
+  if (!Array.isArray(currentValue)) {
+    throw new TypeError('Cannot apply "insertIfMissing()" on non-array value')
+  }
+
+  if (op.items.length === 0) {
+    return currentValue
+  }
+  const itemsToInsert = op.items.filter(
+    item =>
+      !currentValue.find(existing => item._key === (existing as any)?._key),
+  )
+
+  if (itemsToInsert.length === 0) {
+    return currentValue
+  }
+
+  // Insert the items that doesn't exist
+  return insert(
+    {
+      type: 'insert',
+      items: itemsToInsert,
+      referenceItem: op.referenceItem,
+      position: op.position,
+    },
+    currentValue,
   )
 }
 

--- a/src/encoders/compact/encode.ts
+++ b/src/encoders/compact/encode.ts
@@ -87,6 +87,15 @@ function encodePatchMutation(
       [op.position, encodeItemRef(op.referenceItem), op.items],
     ]
   }
+  if (op.type === 'insertIfMissing') {
+    return [
+      'patch',
+      'insertIfMissing',
+      id,
+      path,
+      [op.position, encodeItemRef(op.referenceItem), op.items],
+    ]
+  }
   if (op.type === 'assign') {
     return ['patch', 'assign', id, path, [op.value]]
   }

--- a/src/encoders/compact/types.ts
+++ b/src/encoders/compact/types.ts
@@ -37,6 +37,15 @@ export type UpsertMutation = [
   RevisionLock?,
 ]
 
+export type InsertIfMissingMutation = [
+  'patch',
+  'insertIfMissing',
+  Id,
+  CompactPath,
+  [RelativePosition, ItemRef, AnyArray],
+  RevisionLock?,
+]
+
 export type TruncateMutation = [
   'patch',
   'truncate',
@@ -117,6 +126,7 @@ export type CompactPatchMutation =
   | UnsetMutation
   | InsertMutation
   | UpsertMutation
+  | InsertIfMissingMutation
   | TruncateMutation
   | IncMutation
   | DecMutation

--- a/src/encoders/sanity/encode.ts
+++ b/src/encoders/sanity/encode.ts
@@ -125,6 +125,10 @@ function patchToSanity(patch: NodePatch) {
       unset: [stringifyPath(path.concat(op.referenceItem))],
     }
   }
+  if (op.type === 'insertIfMissing') {
+    // note: insertIfMissing currently not supported by sanity, so will always insert at reference position
+    throw new Error('Patch type insertIfMissing is not supported by Sanity')
+  }
   //@ts-expect-error all cases should be covered
   throw new Error(`Unknown operation type ${op.type}`)
 }

--- a/src/formatters/compact.ts
+++ b/src/formatters/compact.ts
@@ -71,7 +71,11 @@ function formatPatchMutation(patch: NodePatch<any>): string {
   if (op.type === 'unassign') {
     return [path, `${op.type}(${JSON.stringify(op.keys)})`].join(': ')
   }
-  if (op.type === 'insert' || op.type === 'upsert') {
+  if (
+    op.type === 'insert' ||
+    op.type === 'upsert' ||
+    op.type === 'insertIfMissing'
+  ) {
     return [
       path,
       `${op.type}(${op.position}, ${encodeItemRef(

--- a/src/mutations/operations/creators.ts
+++ b/src/mutations/operations/creators.ts
@@ -1,4 +1,4 @@
-import {arrify} from '../../utils/arrify'
+import {type Arrify, arrify} from '../../utils/arrify'
 import {
   type AnyArray,
   type ArrayElement,
@@ -10,6 +10,7 @@ import {
   type DiffMatchPatchOp,
   type IncOp,
   type Index,
+  type InsertIfMissingOp,
   type InsertOp,
   type KeyedPathElement,
   type RelativePosition,
@@ -163,6 +164,26 @@ export function upsert<
   return {
     type: 'upsert',
     items: arrify(items) as Items,
+    referenceItem,
+    position,
+  }
+}
+
+/*
+use this when the reference Items may or may not exist
+ */
+export function insertIfMissing<
+  const Items extends {_key: string}[] | {_key: string},
+  const Pos extends RelativePosition,
+  const ReferenceItem extends Index | KeyedPathElement,
+>(
+  items: Items,
+  position: Pos,
+  referenceItem: ReferenceItem,
+): InsertIfMissingOp<Arrify<Items>, Pos, ReferenceItem> {
+  return {
+    type: 'insertIfMissing',
+    items: arrify(items) as Arrify<Items>,
     referenceItem,
     position,
   }

--- a/src/mutations/operations/creators.ts
+++ b/src/mutations/operations/creators.ts
@@ -173,17 +173,17 @@ export function upsert<
 use this when the reference Items may or may not exist
  */
 export function insertIfMissing<
-  const Items extends {_key: string}[] | {_key: string},
+  const Item extends {_key: string},
   const Pos extends RelativePosition,
   const ReferenceItem extends Index | KeyedPathElement,
 >(
-  items: Items,
+  items: Item | Item[],
   position: Pos,
   referenceItem: ReferenceItem,
-): InsertIfMissingOp<Arrify<Items>, Pos, ReferenceItem> {
+): InsertIfMissingOp<Arrify<Item>, Pos, ReferenceItem> {
   return {
     type: 'insertIfMissing',
-    items: arrify(items) as Arrify<Items>,
+    items: arrify(items) as Arrify<Item>,
     referenceItem,
     position,
   }

--- a/src/mutations/operations/types.ts
+++ b/src/mutations/operations/types.ts
@@ -70,6 +70,17 @@ export type UpsertOp<
   position: Pos
 }
 
+export type InsertIfMissingOp<
+  Items extends AnyArray<{_key: string}>,
+  Pos extends RelativePosition,
+  ReferenceItem extends Index | KeyedPathElement,
+> = {
+  type: 'insertIfMissing'
+  items: Items
+  referenceItem: ReferenceItem
+  position: Pos
+}
+
 export type AssignOp<T extends object = object> = {
   type: 'assign'
   value: T
@@ -94,6 +105,7 @@ export type ObjectOp = AssignOp | UnassignOp
 export type ArrayOp =
   | InsertOp<AnyArray, RelativePosition, Index | KeyedPathElement>
   | UpsertOp<AnyArray, RelativePosition, Index | KeyedPathElement>
+  | InsertIfMissingOp<AnyArray, RelativePosition, Index | KeyedPathElement>
   | ReplaceOp<AnyArray, Index | KeyedPathElement>
   | TruncateOp
   | RemoveOp<Index | KeyedPathElement>


### PR DESCRIPTION
Adds support for creating and applying `insertIfMissing` patches. Note: this patch type is not supported by the mutate endpoint, so it will fail if you try to encode as a sanity mutation.

A case where this is useful is e.g. if you fetch a document that contains an array, and you want to make sure a certain element exist in the array without modifying its content. You can then apply an insertIfMissing patch locally, then post it as a `set` patch to the API (ideally with a revision guard). This will make sure the array is kept "stable" and multiplayer-safe while at the same time making sure elements with certain keys exists.

```ts
import {applyPatches} from '@sanity/mutate/_unstable_apply'

const id = 'my-doc'
const doc = await fetchDocument(id)

const updatedDoc = applyPatches([
  at('items', setIfMissing([])),
  // make sure the item with _key: 'xyz' exists in the array.
  // If it exists: leave it unmodified. If it doesn't: insert it at the end with title: 'initial value'
  at('items', insertIfMissing([{_key: 'xyz', title: 'initial value'}], 'after', -1))
], doc)

// now, items can safely be used in a `set` patch to the API, and the item
// with `_key='xyz'` is guaranteed to be in the array, as it will be added
// at the end if it didn't exist, or left at its current value and position if it was already present
client.patch(id)
  .set({items: updatedDoc.items})
  .ifRevisionId(doc._rev)
```