### PR TITLE
fix: remove duplicate function

### DIFF
--- a/src/mutations/operations/creators.ts
+++ b/src/mutations/operations/creators.ts
@@ -173,26 +173,6 @@ export function upsert<
 use this when the reference Items may or may not exist
  */
 export function insertIfMissing<
-  const Items extends {_key: string}[] | {_key: string},
-  const Pos extends RelativePosition,
-  const ReferenceItem extends Index | KeyedPathElement,
->(
-  items: Items,
-  position: Pos,
-  referenceItem: ReferenceItem,
-): InsertIfMissingOp<Arrify<Items>, Pos, ReferenceItem> {
-  return {
-    type: 'insertIfMissing',
-    items: arrify(items) as Arrify<Items>,
-    referenceItem,
-    position,
-  }
-}
-
-/*
-use this when the reference Items may or may not exist
- */
-export function insertIfMissing<
   const Item extends {_key: string},
   const Pos extends RelativePosition,
   const ReferenceItem extends Index | KeyedPathElement,


### PR DESCRIPTION
Looks like a duplicate function declaration made its way into main. This removes the outdated/wrong one.
